### PR TITLE
Adds ability to mute comments based on IDs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,12 @@ import { comments } from "./requests"
 const github = GitHub(process.env.GITHUB_ACCESS_TOKEN)
 const port = Number(process.env.PORT) || 5000
 const owner = process.env.ONLY_OWNER
+const mutedCommentIDsUnparsed = process.env.MUTED_COMMENT_IDS
+const mutedCommentIDs = mutedCommentIDsUnparsed ? Array.from(mutedCommentIDsUnparsed.split(","), Number) : []
+
+interface Comment {
+  id: number
+}
 
 const app = express()
 app.set("port", port)
@@ -17,12 +23,12 @@ app.get("/repos/:owner/:repo/issues/:number/comments", (req, res) => {
 
   const repo = req.params.repo
   const number = req.params.number
-  comments(owner, repo, number, github).then(comments => {
+  comments(owner, repo, number, github).then((comments: Comment[]) => {
     res.header("Access-Control-Allow-Origin", "*")
     res.header("Access-Control-Allow-Methods", "GET,PUT,POST,DELETE")
     res.header("Access-Control-Allow-Headers", "Content-Type, Authorization")
     res.status(200)
-    res.json(comments)
+    res.json(comments.filter(comment => !mutedCommentIDs.includes(comment.id)))
   })
 })
 app.get("/", (request, res) => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,14 +3,9 @@
     "module": "commonjs",
     "target": "es5",
     "outDir": "dist",
-    "lib": [
-      "es6"
-    ],
+    "lib": ["es6", "es2017"],
     "sourceMap": true,
     "rootDir": "src/"
   },
-  "exclude": [
-    "**/*.test.ts",
-    "node_modules"
-  ]
+  "exclude": ["**/*.test.ts", "node_modules"]
 }


### PR DESCRIPTION
This allows us to keep comments on the GitHub comment issue (optionally marking them as off-topic) while filtering them from appearing in the web interface itself. Once merged, we can PR this back to @orta's repo.